### PR TITLE
Use color.c to print ANSI colors.

### DIFF
--- a/describe.h
+++ b/describe.h
@@ -11,6 +11,7 @@
 #define DESCRIBE_H 1
 
 #include "assertion-macros/assertion-macros.h"
+#include "color/color.c"
 
 #define DESCRIBE_VERSION "1.0.0"
 #define DESCRIBE_OK      "✓"
@@ -34,11 +35,16 @@
 #define it(specification, fn) ({ \
   int before = assert_failures(); \
   fn; \
+  char *status; \
   if (assert_failures() == before) { \
-    printf("    \e[92m%s \e[90m%s\e[0m\n", DESCRIBE_OK, specification); \
+    status = color((ansi_color_opts){.color=ANSI_COLOR_GREEN}, DESCRIBE_OK); \
   } else { \
-    printf("    \e[90m%s \e[90m%s\e[0m\n", DESCRIBE_FAIL, specification); \
+    status = color((ansi_color_opts){.color=ANSI_COLOR_RED}, DESCRIBE_FAIL); \
   } \
+  char *spec = color((ansi_color_opts){.color=ANSI_COLOR_GRAY}, specification); \
+  printf("    %s %s\n", status, spec); \
+  free(status); \
+  free(spec); \
 });
 
 #endif

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "src": [ "describe.h" ],
   "dependencies": {
-    "stephenmathieson/assertion-macros.h": "0.2.0"
+    "stephenmathieson/assertion-macros.h": "0.2.0",
+    "modocache/color.c": "0.1.0"
   }
 }


### PR DESCRIPTION
- Use modocache/color.c to print ANSI escaped color strings.
- Print `DESCRIBE_FAIL` in red, not gray.

---

I whipped up a small package to handle ANSI color codes. It can be used in [stephenmathieson/clib-package](https://github.com/stephenmathieson/clib-package), too, but first I thought I'd get your opinion on it here. Let me know what you think! :neckbeard: 
