### PR TITLE
Change API to support breakpoints in Xcode

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+2.0.0 / 2015-08-13
+==================
+
+ * Change API to support multiple `describe` statements.
+ * Fix XCode not accepting breakpoints when using `describe.h`.
 
 1.1.0 / 2014-03-27
 ==================

--- a/Readme.md
+++ b/Readme.md
@@ -14,26 +14,31 @@
 ```c
 #include "describe.h"
 
-describe("my program", {
-  it("should do stuff", {
-    assert(12 == 12);
-  });
+int main(void) {
+  describe("my program") {
+    it("should do stuff") {
+      assert(12 == 12);
+    }
 
-  it("should fail sometimes", {
-    assert(0 == 12);
-  });
+    it("should fail sometimes") {
+      assert(0 == 12);
+    }
 
-  it("should be ok after failures", {
-    assert(1 == 1);
-  });
+    it("should be ok after failures") {
+      assert(1 == 1);
+    }
 
-  it("should bundle assertion macros", {
-    assert_equal(1, 1);
-    assert_not_equal(1, 2);
-    assert_str_equal("hello", "hello");
-    assert_str_not_equal("hello", "world");
-  });
-});
+    it("should bundle assertion macros") {
+      assert_equal(1, 1);
+      assert_not_equal(1, 2);
+      assert_str_equal("hello", "hello");
+      assert_str_not_equal("hello", "world");
+      assert_null(NULL);
+      assert_not_null("not null");
+    }
+  }
+  return assert_failures();
+}
 ```
 
 ## License
@@ -41,6 +46,7 @@ describe("my program", {
 (The MIT License)
 
 Copyright (c) 2013 Stephen Mathieson &lt;me@stephenmathieson.com&gt;
+Copyright (c) 2015 Michael Phan-Ba &lt;michael@mikepb.com&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/describe.h
+++ b/describe.h
@@ -3,6 +3,7 @@
 // describe.h
 //
 // Copyright (c) 2013 Stephen Mathieson
+// Copyright (c) 2015 Michael Phan-Ba
 // MIT licensed
 //
 
@@ -17,45 +18,48 @@
 #define DESCRIBE_OK      "✓"
 #define DESCRIBE_FAIL    "✖"
 
+void __describe_after_spec(const char *specification, int before) {
+  if (assert_failures() == before) {
+    cc_fprintf(
+        CC_FG_DARK_GREEN
+      , stdout
+      , "    %s"
+      , DESCRIBE_OK
+    );
+  } else {
+    cc_fprintf(
+        CC_FG_DARK_RED
+      , stdout
+      , "    %s"
+      , DESCRIBE_FAIL
+    );
+  }
+  cc_fprintf(
+      CC_FG_GRAY
+    , stdout
+    , " %s\n"
+    , specification
+  );
+}
+
 /*
  * Describe `suite` with `title`
  */
 
-#define describe(title, suite) int main(void) { \
-  printf("\n  %s\n", title); \
-  suite; \
-  printf("\n"); \
-  return assert_failures(); \
-}
+#define describe(title) for (                     \
+  int __run = 0;                                  \
+  __run++ == 0 && printf("\n  %s\n", title);      \
+  printf("\n")                                    \
+)
 
 /*
  * Describe `fn` with `specification`
  */
 
-#define it(specification, fn) ({     \
-  int before = assert_failures();    \
-  fn;                                \
-  if (assert_failures() == before) { \
-    cc_fprintf(                      \
-        CC_FG_DARK_GREEN             \
-      , stdout                       \
-      , "    %s"                     \
-      , DESCRIBE_OK                  \
-    );                               \
-  } else {                           \
-    cc_fprintf(                      \
-        CC_FG_DARK_RED               \
-      , stdout                       \
-      , "    %s"                     \
-      , DESCRIBE_FAIL                \
-    );                               \
-  }                                  \
-  cc_fprintf(                        \
-      CC_FG_GRAY                     \
-    , stdout                         \
-    , " %s\n"                        \
-    , specification                  \
-  );                                 \
-});
+#define it(specification) for (                   \
+  int __before = assert_failures(), __run = 0;    \
+  __run++ == 0;                                   \
+  __describe_after_spec(specification, __before)  \
+)
 
 #endif

--- a/example.c
+++ b/example.c
@@ -1,25 +1,28 @@
 
 #include "describe.h"
 
-describe("my program", {
-  it("should do stuff", {
-    assert(12 == 12);
-  });
+int main(void) {
+  describe("my program") {
+    it("should do stuff") {
+      assert(12 == 12);
+    }
 
-  it("should fail sometimes", {
-    assert(0 == 12);
-  });
+    it("should fail sometimes") {
+      assert(0 == 12);
+    }
 
-  it("should be ok after failures", {
-    assert(1 == 1);
-  });
+    it("should be ok after failures") {
+      assert(1 == 1);
+    }
 
-  it("should bundle assertion macros", {
-    assert_equal(1, 1);
-    assert_not_equal(1, 2);
-    assert_str_equal("hello", "hello");
-    assert_str_not_equal("hello", "world");
-    assert_null(NULL);
-    assert_not_null("not null");
-  });
-});
+    it("should bundle assertion macros") {
+      assert_equal(1, 1);
+      assert_not_equal(1, 2);
+      assert_str_equal("hello", "hello");
+      assert_str_not_equal("hello", "world");
+      assert_null(NULL);
+      assert_not_null("not null");
+    }
+  }
+  return assert_failures();
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "describe",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "repo": "stephenmathieson/describe.h",
   "description": "Simple BDD describe test thingy",
   "keywords": [ "testing", "bdd", "assert", "describe" ],


### PR DESCRIPTION
Hello @stephenmathieson !

I've been enjoying writing tests using this library, but I had a hard time not being able to set breakpoints in Xcode to debug failures. This pull request changes the API such that the macros use the `for` construct to allow Xcode (`lldb`) to set breakpoints in the test code. The change may also allow `gdb` to set breakpoints if it does not already support it.

Summary of changes:
- Fix XCode not accepting breakpoints when using `describe.h`
- Change API to support multiple `describe` statements. 

These changes may lend well to supporting issues #1 and #4 in the future.

Let me know what you think!